### PR TITLE
Increased timeout and maximum age for location request

### DIFF
--- a/mainapp/templates/mainapp/request_form.html
+++ b/mainapp/templates/mainapp/request_form.html
@@ -48,9 +48,7 @@
 		var gpsAccuracyField = document.getElementById('id_latlng_accuracy');
 		gpsAccuracyField.readOnly = true;
 		var options = {
-			enableHighAccuracy: true,
-			timeout: 5000,
-			maximumAge: 0
+			enableHighAccuracy: true
 		};
 
 		var success = function(pos) {


### PR DESCRIPTION
Increasing maximum timeout for fetching location from 5 seconds to Infinity. Otherwise, accurate GPS fetching will not be possible.