### PR TITLE
Issue template and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+### Subject of the issue
+Describe your issue here.
+
+### Your environment
+* version of your python
+* which browser and its version
+
+### Steps to reproduce
+Tell us how to reproduce this issue. Please provide a working demo as a GIF, if possible.
+
+### Expected behaviour
+Tell us what and how exactly is it supposed to  happen
+
+### Actual behaviour
+Tell us what happens instead or what went wrong
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,6 +4,7 @@ Describe your issue here.
 ### Your environment
 * version of your python
 * which browser and its version
+* OS Type (iOS/Android/Linux/Windows)
 
 ### Steps to reproduce
 Tell us how to reproduce this issue. Please provide a working demo as a GIF, if possible.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+
+### Summarize
+Please, describe what the PR does, the changes you have made.
+
+
+> Also, mention the key points if any to look into while code reviews
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
+### Issue Reference
+This PR addresses the Issue : Fixes #
 
 ### Summarize
 Please, describe what the PR does, the changes you have made.
-
 
 > Also, mention the key points if any to look into while code reviews
 


### PR DESCRIPTION
### Issue Reference
This PR addresses a suggestion from #92 and Fixes #99 

### Summarize
This adds two files under the hidden `.github` folder, that helps as a guideline for creating Issues and PRs.
Users can follow those templates so that the workflow becomes easier on both ends of development.

> Let me know if there is anything we can add to this.




