### PR TITLE
Feat: Add "map-view" page for received requests.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ ALLOWED_HOSTS=localhost
 SENTRY_DSN=""
 B_DATABASE_URL="postgres://rescueuser:password@localhost/rescuekerala"
 DEBUG=true
+
+# Google maps API KEY. The application seems to be working with empty a key too :o
+G_MAPS_API_KEY="AIzaSyB6bkKAZhivi80ap5ak-Jonv6GSHzVLbao"

--- a/floodrelief/settings.py
+++ b/floodrelief/settings.py
@@ -185,3 +185,4 @@ STATICFILES_DIRS = (
 )
 
 ADMIN_SITE_HEADER = "Keralarescue Dashboard"
+G_MAPS_API_KEY = env('G_MAPS_API_KEY')

--- a/mainapp/templates/mainapp/request_list.html
+++ b/mainapp/templates/mainapp/request_list.html
@@ -6,6 +6,7 @@
 <form action="" method="get" class="text-center">
        {{ filter.form.as_p }}
        <input value="View requests" class="btn btn-primary" type="submit" />
+       <button class="btn btn-primary" type="submit" name="view" value="map" >View Map</button>
  </form>
  <div class="table-responsive">
   <table class="table">

--- a/mainapp/templates/mainapp/request_map.html
+++ b/mainapp/templates/mainapp/request_map.html
@@ -1,0 +1,78 @@
+{% extends 'base.html' %}
+{% load bootstrap3 %}
+
+{% block content %}
+
+<form action="" method="get" class="text-center">
+       {{ filter.form.as_p }}
+       <input value="View requests" class="btn btn-primary" type="submit" />
+       <button class="btn btn-primary" type="submit" name="view" value="map" >View Map</button>
+</form>
+<div class="row">
+  <div class="col-12">
+    <div id="map" style="height: 500px;" >
+    </div>
+  </div>
+</div>
+
+<script>
+{% autoescape off %}
+var reqData = {{ data.items }};
+window.reqData = reqData;
+{% endautoescape %}
+function reqToPosition( req ){
+  var latlng = req.fields.latlng;
+  if( !latlng ){
+    return;
+  }
+  latlng = latlng.split(',').map( parseFloat );
+  var position = {
+    lat: latlng[0],
+    lng: latlng[1]
+  };
+  var label = '#' + req.pk ;
+  var content = '<b>Location: </b>' + req.fields.location +
+    '<br/><b>Requestee: </b>' + req.fields.requestee +
+    '<br/><b>Requested At: </b>' + new Date( req.fields.dateadded  ).toLocaleString() +
+    '<br/><b>Phone: </b>' + req.fields.requestee_phone;
+
+  return {
+    position: position,
+    label: label,
+    content: content,
+  };
+}
+
+function initMap() {
+  var myLatLng = {lat: 10.523856, lng: 76.213900 };
+
+  var map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 12,
+    center: myLatLng
+  });
+
+  reqData.map( reqToPosition ).forEach( function( data ){
+    if( !data ){
+      return;
+    }
+    var image = 'https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png';
+    var marker = new google.maps.Marker({
+      position: data.position,
+      map: map,
+      label: data.label,
+      // icon: image,
+    });
+    var infowindow = new google.maps.InfoWindow({
+      content: data.content
+    });
+
+    marker.addListener('click', function() {
+      infowindow.open(map, marker);
+    });
+
+  });
+}
+</script>
+
+<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ data.G_MAPS_API_KEY }}&callback=initMap"> </script>
+{% endblock %}

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -7,6 +7,8 @@ import django_filters
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import JsonResponse
 from django.http import HttpResponseRedirect
+from django.core import serializers
+from django.conf import settings
 
 class CreateRequest(CreateView):
     model = Request
@@ -109,6 +111,10 @@ def request_list(request):
     paginator = Paginator(req_data, 100)
     page = request.GET.get('page')
     req_data = paginator.get_page(page)
+    if request.GET.get('view') == 'map':
+        req_data = { 'items': serializers.serialize("json", req_data) }
+        req_data['G_MAPS_API_KEY'] = settings.G_MAPS_API_KEY
+        return render(request, 'mainapp/request_map.html', {'filter': filter , "data" : req_data })
     return render(request, 'mainapp/request_list.html', {'filter': filter , "data" : req_data })
 
 


### PR DESCRIPTION
Just mark the requests with with GPS location in the map and display the details.

### Summarize
We are already saving GPS location information while relieving new requests.
This PR provides a "map-view" page for visually displaying the location of each requests in a Google map.
![image](https://user-images.githubusercontent.com/1652903/44229246-164b8280-a1b5-11e8-8a7b-58a4ff5114a2.png)

![image](https://user-images.githubusercontent.com/1652903/44229296-3d09b900-a1b5-11e8-804c-fcfbc3b23a71.png)


> Also, mention the key points if any to look into while code reviews
We need to put Google maps API key in .env file. But the applications seems to be working without a key also . I don't know

This PR is related to following issues
* https://github.com/IEEEKeralaSection/rescuekerala/issues/174
* https://github.com/IEEEKeralaSection/rescuekerala/issues/72
