### PR TITLE
request_list table removed District column

### DIFF
--- a/mainapp/templates/mainapp/request_list.html
+++ b/mainapp/templates/mainapp/request_list.html
@@ -10,18 +10,15 @@
  <div class="table-responsive">
   <table class="table">
     <tr>
-      <th>District</th>
       <th>Location</th>
       <th>GPS Location</th>
       <th>Requestee</th>
       <th>Contact number</th>
       <th>Summary of request</th>
-      <th>Date</th>
     </tr>
     {% for req in data %}
         <tr>
-          <td>{{ req.get_district_display }}</td>
-          <td>{{ req.location }}</td>
+          <td>{{ req.location }} <span class="label">{{ req.dateadded }}</span></td>
           <td>
             {% if req.latlng %}
               <a class="btn btn-sm btn-success" href="https://maps.google.com/?q={{ req.latlng }}" target="_blank">Open in maps</a>
@@ -34,7 +31,6 @@
           <td>{{ req.requestee }}</td>
           <td><a href="tel:{{ req.requestee_phone }}" >{{ req.requestee_phone }}</a></td> 
           <td>{{ req.summarise | linebreaks }}</td>
-          <td>{{ req.dateadded }}</td>
         </tr>
     {% endfor %}
 

--- a/mainapp/templates/mainapp/request_list.html
+++ b/mainapp/templates/mainapp/request_list.html
@@ -18,7 +18,7 @@
     </tr>
     {% for req in data %}
         <tr>
-          <td>{{ req.location }} <span class="label">{{ req.dateadded }}</span></td>
+          <td>{{ req.location }} requested on <span class="label">{{ req.dateadded }}</span></td>
           <td>
             {% if req.latlng %}
               <a class="btn btn-sm btn-success" href="https://maps.google.com/?q={{ req.latlng }}" target="_blank">Open in maps</a>


### PR DESCRIPTION
### Issue Reference
#147 

### Summarize
Removed district column from request list table. No need to show district column when it is already filtered by districts saves space on mobile views.
Timestamp is moved under Location column as span as this is tiny information.


