### PR TITLE
More generic command for starting the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python3 manage.py collectstatic
 Run the server
 
 ```
-python3 manage.py runserver
+python3 manage.py runserver 0.0.0.0:8000
 ```
 Now open localhost:8000 in the browser
 


### PR DESCRIPTION
Just a suggestion for Readme doc: Edited the command for starting the server to a more generic form so that the server binds to all IPs in the host machine.
This form of command may be helpful to avoid some hard-to-figure-out issues for newly joining devs.