### PR TITLE
Query request by -id instead of -dateadded. 

### DIFF
--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -114,7 +114,7 @@ class RequestFilter(django_filters.FilterSet):
 
 def request_list(request):
     filter = RequestFilter(request.GET, queryset=Request.objects.all() )
-    req_data = filter.qs.order_by('-dateadded')
+    req_data = filter.qs.order_by('-id')
     paginator = Paginator(req_data, 100)
     page = request.GET.get('page')
     req_data = paginator.get_page(page)


### PR DESCRIPTION


Has the same effect. But uses the default index

### Issue Reference
This PR addresses the Issue : Improves #284 

### Summarize
```
The original query does:
 WHERE "mainapp_request"."district" = 'ekm' ORDER BY "mainapp_request"."dateadded" DESC  LIMIT 100;
                                   QUERY PLAN                                    
---------------------------------------------------------------------------------
 Limit  (cost=172.02..172.27 rows=100 width=227)
   ->  Sort  (cost=172.02..174.46 rows=977 width=227)
         Sort Key: dateadded DESC
         ->  Seq Scan on mainapp_request  (cost=0.00..134.68 rows=977 width=227)
               Filter: ((district)::text = 'ekm'::text)
(5 rows)

```
With this change queries are more efficient. Seq scans are bad. Index scans are good.
```
rescuekerala=> explain SELECT .... "mainapp_request"."dateadded" FROM "mainapp_request" WHERE "mainapp_request"."district" = 'ekm' ORDER BY "mainapp_request"."id" DESC  LIMIT 100;
                                                   QUERY PLAN                                                    
-----------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.28..20.50 rows=100 width=227)
   ->  Index Scan Backward using mainapp_request_pkey on mainapp_request  (cost=0.28..197.84 rows=977 width=227)
         Filter: ((district)::text = 'ekm'::text)
(3 rows)
```
