### PR TITLE
Load request page with data

### DIFF
--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -7,6 +7,7 @@ import django_filters
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import JsonResponse
 from django.http import HttpResponseRedirect
+from django.http import QueryDict
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
@@ -124,7 +125,10 @@ class RequestFilter(django_filters.FilterSet):
 
 
 def request_list(request):
-    filter = RequestFilter(request.GET, queryset=Request.objects.all() )
+    if bool(request.GET) == False:
+        filter = RequestFilter(QueryDict('district=&requestee__icontains=&requestee_phone=&location__icontains='), queryset=Request.objects.all())
+    else:
+        filter = RequestFilter(request.GET, queryset=Request.objects.all() )
     req_data = filter.qs.order_by('-id')
     paginator = Paginator(req_data, 100)
     page = request.GET.get('page')

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -7,7 +7,6 @@ import django_filters
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import JsonResponse
 from django.http import HttpResponseRedirect
-from django.http import QueryDict
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -125,10 +125,7 @@ class RequestFilter(django_filters.FilterSet):
 
 
 def request_list(request):
-    if bool(request.GET) == False:
-        filter = RequestFilter(QueryDict('district=&requestee__icontains=&requestee_phone=&location__icontains='), queryset=Request.objects.all())
-    else:
-        filter = RequestFilter(request.GET, queryset=Request.objects.all() )
+    filter = RequestFilter(request.GET, queryset=Request.objects.all() )
     req_data = filter.qs.order_by('-id')
     paginator = Paginator(req_data, 100)
     page = request.GET.get('page')

--- a/templates/home.html
+++ b/templates/home.html
@@ -54,7 +54,7 @@
             <span class="ml small">ഞങ്ങളുമായി ബന്ധപ്പെടാന്‍</span>
         </span>
     </a>
-    <a href="/requests" class="home-button card" role="button">
+    <a href="/requests/?district=" class="home-button card" role="button">
       {% bootstrap_icon "list" %}
       <span class="text">
         Registered Requests<br/>


### PR DESCRIPTION
### Summarize

Currently the /request page loads with no data which can be confusing
to new users. This allows the page to always load with data and can be
modified as was earlier using the form
