### PR TITLE
Removed unused font to avoid loading the font

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -71,7 +71,6 @@
   </div>
 </footer>
 
-<link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 {% bootstrap_javascript %}


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #383

### Summarize
Loads the font from google fonts even though it is not used. This uses unnecessary bandwidth.

