### PR TITLE
Added Support chat option on home page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -75,4 +75,18 @@
         സഹായത്തിനായി വൊളന്‍റീയര്‍മാര്‍ തയ്യാറാണ്. സഹായം ആവശ്യമെങ്കില്‍ ഒരോ ജില്ലയിലെയും നിയോഗിക്കപെട്ട ഉദ്യോഗസ്ഥരുമായി ബന്ധപ്പെടാം
     </p>
 </div>
+
+<!--Start of Tawk.to Script-->
+<script type="text/javascript">
+    var Tawk_API = Tawk_API || {}, Tawk_LoadStart = new Date();
+    (function () {
+        var s1 = document.createElement("script"), s0 = document.getElementsByTagName("script")[0];
+        s1.async = true;
+        s1.src = 'https://embed.tawk.to/5b765327afc2c34e96e7a786/default';
+        s1.charset = 'UTF-8';
+        s1.setAttribute('crossorigin', '*');
+        s0.parentNode.insertBefore(s1, s0);
+    })();
+</script>
+<!--End of Tawk.to Script-->
 {% endblock %}


### PR DESCRIPTION
I have added a script for integrating a volunteer chat option. Right now we are providing chat support on a different domain with the help of many active volunteers from the slack group.  The same script is used here also to provide chat support to the visitors of this site also. Testing is required before merging.

**Please test load time and network performance as well.** 

The working functionality can be seen here:- http://keralarescuesupport.com/

Eg Image:-

![image](https://user-images.githubusercontent.com/32065631/44271892-f53c6d80-a258-11e8-9635-7d922130e8b9.png)
