### PR TITLE
added spaceless to base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% spaceless %}
 {% load static %}
 {% load bootstrap3 %}
 
@@ -87,3 +88,4 @@
 </body>
 
 </html>
+{% endspaceless %}


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #426

### Summarize
This PR adds `spaceless` to base template which reduces the rendered html footprint, ie; minor amount bandwidth saved.