### PR TITLE
fixes the phone input on mobile browsers

### DIFF
--- a/mainapp/templates/mainapp/request_form.html
+++ b/mainapp/templates/mainapp/request_form.html
@@ -85,7 +85,7 @@
 	}
 
 	window.onload = function(){
-        $("#id_requestee_phone").attr('type', 'number');
+    $("#id_requestee_phone").attr('type', 'tel');
 		var gpsField = document.getElementById('id_latlng');
 		var gpsAccuracyField = document.getElementById('id_latlng_accuracy');
 		gpsField.readOnly = true;


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #488 

### Summarize
Changed the input type of the requestee phone number from `number` to `tel`

Before:
![img_7393](https://user-images.githubusercontent.com/527535/44293049-02715080-a289-11e8-997c-d1e5ef72dd69.PNG)

After:
![img_7392](https://user-images.githubusercontent.com/527535/44293054-08673180-a289-11e8-8044-edb400ef353c.jpg)

> Not sure if this was done intentionally, and there's a reasoning to it.  

Tested only on Mobile Safari.

