### PR TITLE
Truncate map data requests to last 24 hours

### DIFF
--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -19,6 +19,7 @@ from django.contrib.auth.decorators import login_required
 from django.urls import reverse
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.http import Http404
+from datetime import datetime, timedelta
 
 class CreateRequest(CreateView):
     model = Request
@@ -181,7 +182,8 @@ def mapdata(request):
     if district != "all":
         data = Request.objects.exclude(latlng__exact="").filter(district=district).values()
     else:
-        data = Request.objects.exclude(latlng__exact="").values()
+        from_date = datetime.today() - timedelta(hours=24)
+        data = Request.objects.filter(dateadded__gt=from_date).exclude(latlng__exact="").values()
     cache.set("mapdata:" + district, data, settings.CACHE_TIMEOUT)
     return JsonResponse(list(data) , safe=False)
 


### PR DESCRIPTION
Truncate the request data used to populate at state level, to last 24 hours.

### Issue Reference
This PR addresses the Issue : Fixes #

### Summarize
Please, describe what the PR does, the changes you have made.

> Also, mention the key points if any to look into while code reviews

