### PR TITLE
Urgent: Remove user authorization for relief camps

### DIFF
--- a/mainapp/templates/mainapp/coordinator_home.html
+++ b/mainapp/templates/mainapp/coordinator_home.html
@@ -23,6 +23,11 @@
     {% endif %}
 </div>
 
+<form action="" method="get">
+    {{ filter.form }}
+    <button class="btn btn-default" type="submit"> Select {% bootstrap_icon "chevron-right" %}</button>
+</form>
+
 {% if camps.count > 0 %}
 <div class="row">
 {% for item in camps %}
@@ -52,7 +57,7 @@
 {% else  %}
 <div class="text-center text-warning">
   <h4>
-      No relief camps configured for this user yet.
+      No relief camps found.
   </h4>
   
 </div>

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -246,6 +246,7 @@ class AddPerson(SuccessMessageMixin,LoginRequiredMixin,CreateView):
 
     def get_success_url(self):
         return reverse('add_person', args=(self.camp_id,))
+
     def dispatch(self, request, *args, **kwargs):
         self.camp_id = kwargs.get('camp_id','')
         
@@ -253,8 +254,11 @@ class AddPerson(SuccessMessageMixin,LoginRequiredMixin,CreateView):
             self.camp = RescueCamp.objects.get(id=int(self.camp_id))
         except ObjectDoesNotExist:
             raise Http404
-        if request.user!=self.camp.data_entry_user:
-            raise PermissionDenied
+
+        # Commented to allow all users to edit all camps
+        # if request.user!=self.camp.data_entry_user:
+        #     raise PermissionDenied
+
         return super(AddPerson, self).dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):
@@ -292,11 +296,12 @@ class CampDetails(SuccessMessageMixin,LoginRequiredMixin,UpdateView):
     success_url = '/coordinator_home/'
     success_message = "Updated requirements saved!"
 
-    def dispatch(self, request, *args, **kwargs):
-        if request.user!=self.get_object().data_entry_user:
-            raise PermissionDenied
-        return super(CampDetails, self).dispatch(
-            request, *args, **kwargs)
+    # Commented to allow all users to edit all camps
+    # def dispatch(self, request, *args, **kwargs):
+    #     if request.user!=self.get_object().data_entry_user:
+    #         raise PermissionDenied
+    #     return super(CampDetails, self).dispatch(
+    #         request, *args, **kwargs)
 
 class PeopleFilter(django_filters.FilterSet):
     fields = ['name', 'phone','address','district','notes','gender','camped_at']
@@ -331,5 +336,7 @@ def find_people(request):
 
 @login_required(login_url='/login/')
 def coordinator_home(request):
-    camps = RescueCamp.objects.filter(data_entry_user=request.user)
+    camps = RescueCamp.objects.all()
+    # Commented to allow all users to see all camps
+    # .filter(data_entry_user=request.user)
     return render(request,"mainapp/coordinator_home.html",{'camps':camps})

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -335,8 +335,17 @@ def find_people(request):
     return render(request, 'mainapp/people.html', {'filter': filter , "data" : people })
 
 @login_required(login_url='/login/')
+
 def coordinator_home(request):
-    camps = RescueCamp.objects.all()
+    if not request.GET._mutable:
+        request.GET._mutable = True
+
+    if len(request.GET.get('district') or '') == 0:
+        request.GET['pwd'] = ''
+
+    filter = RescueCampFilter(request.GET, queryset=RescueCamp.objects.all())
+    relief_camps = filter.qs.annotate(count=Count('person')).order_by('district','name').all()
+
     # Commented to allow all users to see all camps
     # .filter(data_entry_user=request.user)
-    return render(request,"mainapp/coordinator_home.html",{'camps':camps})
+    return render(request, "mainapp/coordinator_home.html", {'filter': filter , 'camps' : relief_camps})


### PR DESCRIPTION
### Issue Reference
Authorization is not practical at the moment.

Modified code to allow any user to edit any camp. Also added district filters for coordinator home page.