### PR TITLE
Fixed the bug for otherneeds taking the location value

### DIFF
--- a/mainapp/templates/mainapp/placepicker_form.html
+++ b/mainapp/templates/mainapp/placepicker_form.html
@@ -11,7 +11,7 @@
   <label class="control-label" for="pac-input">
   Enter location manually
 </label>
-<input type="text" name="needothers" maxlength="500" class="form-control" placeholder="Enter location manually" title="" id="pac-input">
+<input type="text" maxlength="500" class="form-control" placeholder="Enter location manually" title="" id="pac-input">
 </div>
 
 


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #528 

### Summarize
When entering the location manually, the locations' value was getting saved in the needothers of the Request model. I have fixed this bug

### How to test

* Create a request, using the "Enter location manually" functionality to pick a location.
* Find this request in the list and click on "more details"
* Confirm that this request doesn't have the location you picked in the "Other needs" detail section.