### PR TITLE
Adds New Feature to update contributer status to fullfilled

### DIFF
--- a/mainapp/admin.py
+++ b/mainapp/admin.py
@@ -94,8 +94,9 @@ class NGOAdmin(admin.ModelAdmin):
 
 
 class ContributorAdmin(admin.ModelAdmin):
-    actions = ['download_csv']
+    actions = ['download_csv', 'mark_as_fullfulled']
     list_filter = ('district', 'status',)
+    list_display = ('district', 'status')
 
     def download_csv(self, request, queryset):
         header_row = [f.name for f in Contributor._meta.get_fields()]
@@ -103,6 +104,10 @@ class ContributorAdmin(admin.ModelAdmin):
 
         response = create_csv_response('Contributors', header_row, body_rows)
         return response
+
+    def mark_as_fullfulled(self, request, queryset):
+        queryset.update(status='ful')
+        return
 
 
 class RescueCampAdmin(admin.ModelAdmin):

--- a/mainapp/admin.py
+++ b/mainapp/admin.py
@@ -94,9 +94,9 @@ class NGOAdmin(admin.ModelAdmin):
 
 
 class ContributorAdmin(admin.ModelAdmin):
-    actions = ['download_csv', 'mark_as_fullfulled']
+    actions = ['download_csv', 'mark_as_fullfulled', 'mark_as_new']
     list_filter = ('district', 'status',)
-    list_display = ('district', 'status')
+    list_display = ('district', 'name', 'phone', 'address', 'commodities', 'status')
 
     def download_csv(self, request, queryset):
         header_row = [f.name for f in Contributor._meta.get_fields()]
@@ -109,6 +109,9 @@ class ContributorAdmin(admin.ModelAdmin):
         queryset.update(status='ful')
         return
 
+    def mark_as_new(self, request, queryset):
+        queryset.update(status='new')
+        return
 
 class RescueCampAdmin(admin.ModelAdmin):
     list_display = ('district', 'name', 'location')


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #

### Summarize
  dpm(disaster program managers) can see the contributers download the details). This is not enough. Should be able to filter using status 'fulfiled' and 'new'. and also update status

