### PR TITLE
instruct travis to use a postgres 9.4 resolve failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 services: 
   - postgresql
   - redis-server
+addons:
+  postgresql: "9.4"
 
 env:
   matrix:


### PR DESCRIPTION
### Issue Reference
travis build seems to be failing.
issue similar to the one being discussed here -> https://groups.google.com/forum/#!topic/django-users/behDaxyzVE8

### Summarize
instructs travis to use postgres 9.4



