### PR TITLE
Added a name attribute to the auto complete field

### DIFF
--- a/mainapp/templates/mainapp/placepicker_form.html
+++ b/mainapp/templates/mainapp/placepicker_form.html
@@ -11,7 +11,7 @@
   <label class="control-label" for="pac-input">
   Enter location manually
 </label>
-<input type="text" maxlength="500" class="form-control" placeholder="Enter location manually" title="" id="pac-input">
+<input name="auto-complete-location" type="text" maxlength="500" class="form-control" placeholder="Enter location manually" title="" id="pac-input">
 </div>
 
 


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #

### Summarize
The request form was saving null values because the autocomplete input tag didn't have a name attribute. This was totally unexpected. I added a name attribute to it which solved the issue.
This needs to be merged asap