### PR TITLE
Show location button if latlng is present even for request-for-others

### DIFF
--- a/mainapp/templates/mainapp/request_details.html
+++ b/mainapp/templates/mainapp/request_details.html
@@ -25,7 +25,7 @@
       <tr>
         <td><b> GPS Location : </b></td>
         <td>
-          {% if not req.is_request_for_others and req.latlng %}
+          {% if req.latlng %}
             <a class="btn btn-sm btn-success" href="https://maps.google.com/?q={{ req.latlng }}" target="_blank">Open in maps</a>
             <br>
             Accuracy: {{ req.latlng_accuracy }}


### PR DESCRIPTION
Partial fix for #607 

Currently NA is being displayed for request created for others instead of location info even if location info is present. This PR fixes that.

This along with #600 fixes #607 