### PR TITLE
Manually enter location is required field if requesting for others

### DIFF
--- a/mainapp/templates/mainapp/request_form.html
+++ b/mainapp/templates/mainapp/request_form.html
@@ -134,6 +134,15 @@
 		showLocationPickerForm();
 	})
 
+	$('#id_is_request_for_others').on('change', function(){
+		if($(this).is(":checked")){
+			$('#pac-input').attr('required', 'required');
+		}
+		else{
+			$('#pac-input').removeAttr('required');
+		}
+	});
+
   </script>
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDdPKYd4vwgQY-OmF0Vn22wJu0EcDyi1MQ&libraries=places&callback=initMap"
         async defer></script>


### PR DESCRIPTION
### Issue Reference
Earlier if the user makes a request for others then he can leave the manually enter the location field empty.
Now if the user makes a request for others then the "manually enter the location" field is set to required.