### PR TITLE
Placepicker form shown now if the user makes request for others

### DIFF
--- a/mainapp/templates/mainapp/request_form.html
+++ b/mainapp/templates/mainapp/request_form.html
@@ -137,6 +137,7 @@
 	$('#id_is_request_for_others').on('change', function(){
 		if($(this).is(":checked")){
 			$('#pac-input').attr('required', 'required');
+			showLocationPickerForm();
 		}
 		else{
 			$('#pac-input').removeAttr('required');


### PR DESCRIPTION
### Summarize
As pointed out by @lijo if the placepicker form is not shown and the user makes for request for someone else than he won't be able to submit the form as the placepicker field will be set to required as in #624 
Now the placepicker filed will be shown if user check making request for other field