### PR TITLE
Make filename unique to avoid S3 replacement

### DIFF
--- a/mainapp/models.py
+++ b/mainapp/models.py
@@ -1,3 +1,5 @@
+import os
+import uuid
 from django.db import models
 from django.core.validators import RegexValidator
 from django.contrib.auth.models import User
@@ -347,6 +349,13 @@ class Person(models.Model):
     def __str__(self):
         return self.name
 
+
+def upload_to(instance, filename):
+    ext = filename.split('.')[-1]
+    filename = "%s.%s" % (uuid.uuid4(), ext)
+    return os.path.join('media/', filename)
+
+
 class Announcements(models.Model):
     dateadded = models.DateTimeField(auto_now_add=True)
     priority = models.CharField(
@@ -356,8 +365,8 @@ class Announcements(models.Model):
         default='L')
 
     description = models.TextField(blank=True)
-    image = models.ImageField(blank=True, upload_to='media')
-    upload = models.FileField(blank=True, upload_to='media')
+    image = models.ImageField(blank=True, upload_to=upload_to)
+    upload = models.FileField(blank=True, upload_to=upload_to)
     is_pinned = models.BooleanField(default=False)
 
     class Meta:


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue (comment 2): Fixes https://github.com/IEEEKeralaSection/rescuekerala/pull/610#issuecomment-414083371

### Summarize
Please, describe what the PR does, the changes you have made.

When a user uploads two files in the same name with different content, s3 replaces the old file. To avoid this conflict, generate a unique name for every file.

> Also, mention the key points if any to look into while code reviews

- Upload two different files in the same name, and open the two uploaded files in the different tabs. Both the files should remain accessible, and notice the new filenames.

@akshayjoyinfo please review this.
