### PR TITLE
Add district field to ngo registration form and option to download by district

### DIFF
--- a/mainapp/models.py
+++ b/mainapp/models.py
@@ -163,6 +163,7 @@ class NGO(models.Model):
     district = models.CharField(
         max_length = 15,
         choices = districts,
+        verbose_name= 'District'
     )
     organisation = models.CharField(max_length=250, verbose_name="Name of Organization (സംഘടനയുടെ പേര്)")
     organisation_type = models.CharField(max_length=250, verbose_name="Type of Organization")

--- a/mainapp/templates/mainapp/ngo_form.html
+++ b/mainapp/templates/mainapp/ngo_form.html
@@ -5,9 +5,9 @@
   <div class="text-right">
     <a href="{% url 'ngo_download_view' %}">Download NGO list</a><br>
     <form style="margin-right: 0;" action="{% url 'ngo_download_view' %}" method="get" name="district">{% csrf_token %}
-      NGO list by District {{ form.district}}
-      <input type="submit" value="Download" />
-  </form>
+      NGO list by District: {{ form.district}}
+      <input style="margin-left: 1%;" type="submit" value="Download" />
+    </form>
   </div>
 
 <p class="text-center">

--- a/mainapp/templates/mainapp/ngo_form.html
+++ b/mainapp/templates/mainapp/ngo_form.html
@@ -3,12 +3,11 @@
 
 {% block content %}
   <div class="text-right">
-    <a href="{% url 'ngo_download_view' %}">Download NGO list</a>
-    <form action="{% url 'ngo_download_view' %}" method="post" name="district">{% csrf_token %}
-      <a >NGO by district  </a>
-      {{ form.district}}
+    <a href="{% url 'ngo_download_view' %}">Download NGO list</a><br>
+    <form style="margin-right: 0;" action="{% url 'ngo_download_view' %}" method="get" name="district">{% csrf_token %}
+      NGO list by District {{ form.district}}
       <input type="submit" value="Download" />
-    </form>
+  </form>
   </div>
 
 <p class="text-center">

--- a/mainapp/templates/mainapp/ngo_form.html
+++ b/mainapp/templates/mainapp/ngo_form.html
@@ -4,6 +4,11 @@
 {% block content %}
   <div class="text-right">
     <a href="{% url 'ngo_download_view' %}">Download NGO list</a>
+    <form action="{% url 'ngo_download_view' %}" method="post" name="district">{% csrf_token %}
+      <a >NGO by district  </a>
+      {{ form.district}}
+      <input type="submit" value="Download" />
+    </form>
   </div>
 
 <p class="text-center">

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -65,7 +65,7 @@ class RegisterVolunteer(CreateView):
 
 class RegisterNGO(CreateView):
     model = NGO
-    fields = ['organisation', 'organisation_type','organisation_address', 'name', 'phone', 'description', 'area',
+    fields = ['organisation', 'organisation_type', 'district', 'organisation_address', 'name', 'phone', 'description', 'area',
               'location']
     success_url = '/reg_success'
 


### PR DESCRIPTION
This PR addresses the Issue : Fixes #642 

The PR modifies the NGO/Company registration form. 
It adds a drop down menu for district as a required field while submitting the form.
This also creates an endpoint to download NGO data by district. 

The changes would reflect on the https://keralarescue.in/NGO/ page.
