### PR TITLE
Fixed UI Distortion for Volunteer and NGO section on the homepage

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -29,13 +29,14 @@
     <a href="/district_needs/" class="home-button card" role="button">
         {% bootstrap_icon "map-marker" %}
         <span class="text">
-            DISTRICT NEEDS &amp; COLLECTION CENTERS<br></span>
+            DISTRICT NEEDS &amp; COLLECTION CENTERS<br/>
             <span class="ml small">ജില്ലകളിലെ ആവശ്യങ്ങള്‍</span>
+        </span>
     </a>
     <a href="/ngo-volunteer/" class="home-button card" role="button">
         {% bootstrap_icon "user" %}
         <span class="text">
-            Register as<br/>a volunteer or NGO
+            Register as<br/>a volunteer or NGO<br/>
             <span class="ml small">വൊളന്‍റീയര്‍ ആകാന്‍</span>
         </span>
     </a>


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #689

### Summarize
* Added line break for "Register as a volunteer or NGO" section, as per the other sections
* Fixed a misplaced _span_ element in the "DISTRICT NEEDS & COLLECTION CENTERS" section

