### PR TITLE
Removed Add Camp data

### DIFF
--- a/mainapp/templates/mainapp/relief_camps.html
+++ b/mainapp/templates/mainapp/relief_camps.html
@@ -45,14 +45,7 @@
             <span class="ml small"></span>
         </span>
     </a>
-    <a href="/add_camp_data" class="home-button card" role="button">
-        {% bootstrap_icon "home" %}
-        <span class="text text-center">
-            Add Data<br/>
-            ക്യാമ്പുകളെ കുറിച്ചുള്ള വിവരങ്ങൾ ചേർക്കുക
-            <span class="ml small"></span>
-        </span>
-    </a>
+
     <p class="home-info">
         Contact Control Room or Disaster Management Cell or District Administration for any support.<br>
         Volunteers may contact District Project Managers for support related to volunteering and contributions<br>


### PR DESCRIPTION
### Issue Reference
This PR hides the feature developed in #668 as it's not required. 

### Testing
The relief camps home page should now have only Relief Camp List and Supply Requirements, with the Add Camp data button removed.