### PR TITLE
/map-view icons made distinct to avoid confusion

### DIFF
--- a/templates/mapview.html
+++ b/templates/mapview.html
@@ -20,7 +20,7 @@
         </span>
     </a>
     <a href="https://www.microid.in/keralaflood/" class="home-button card" role="button">
-        {% bootstrap_icon "globe" %}
+        {% bootstrap_icon "road" %}
         <span class="text">
           Flooded Streets<br/>
           <span class="ml small">റോഡ് ‍</span>


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #715

### Summarize
Changed icon on Flooded Streets to `road`
<img width="508" alt="screen shot 2018-08-19 at 11 52 48 pm" src="https://user-images.githubusercontent.com/1846416/44311769-180e8380-a40b-11e8-9149-83d5acfa1dab.png">

