### PR TITLE
If permission for geolocation is granted or denied, don't show the modal

### DIFF
--- a/mainapp/templates/mainapp/request_form.html
+++ b/mainapp/templates/mainapp/request_form.html
@@ -120,8 +120,18 @@
 		$('#instructionModal').on('hidden.bs.modal', function (e) {
 		  navigator.geolocation.getCurrentPosition(success, error, options);
 		})
-
-		$('#instructionModal').modal('show');
+    try {
+      navigator.permissions.query({'name': 'geolocation'}).then(
+        function(result) {
+          switch (result.state) {
+            case 'prompt': $('#instructionModal').modal('show'); break;
+            case 'granted': navigator.geolocation.getCurrentPosition(success, error, options); break;
+          }
+      })
+    } catch (err) {
+      // capture cases that don't have navigator or navigator.permissions
+      $('#instructionModal').modal('show');
+    }
 	}
 
 	function showLocationPickerForm(){


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #718 

### Summarize
Don't show "Allow Location" modal if `geolocation` permission was already granted or denied.
