### PR TITLE
hide volunteer info

### DIFF
--- a/mainapp/templates/mainapp/volunteer_form.html
+++ b/mainapp/templates/mainapp/volunteer_form.html
@@ -27,9 +27,6 @@
 	        <td><b> Organisation : </b></td><td>{{ form.instance.organisation }}</td>
 	      </tr>
 	      <tr>
-	        <td><b> Phone : </b></td><td>{{ form.instance.phone }}</td>
-	      </tr>
-	      <tr>
 	        <td><b> Consent : </b></td><td>{% if form.instance.has_consented %} yes {% else %} no {% endif %}</td>
 	      </tr>
 		  <tr>

--- a/mainapp/templates/mainapp/volunteerview.html
+++ b/mainapp/templates/mainapp/volunteerview.html
@@ -78,9 +78,11 @@
       <tr>
         <th>District - ജില്ല</th>
         <th>Name - പേര</th>
-        <th>Location - സ്ഥലം</th>
-        <th>Organization - സംഘടന</th>
-        <th>Phone - ഫോണ്‍ നമ്പര്‍</th>
+		{% if user.is_authenticated %}
+			<th>Location - സ്ഥലം</th>
+			<th>Organization - സംഘടന</th>
+			<th>Phone - ഫോണ്‍ നമ്പര്‍</th>
+		{% endif %}
         <th>Area - സന്നദ്ധസേവനം</th>
       </tr>
     </thead>
@@ -89,9 +91,11 @@
         <tr>
           <td>{{ req.get_district_display }}</td>
           <td>{{ req.name }}</td>
-          <td>{{ req.address }}</td>
-          <td>{{ req.organisation }}</td>
-          <td><a href="tel:{{ req.requestee_phone }}" >{{ req.phone }}</a></td>
+		  {% if user.is_authenticated %}
+			  <td>{{ req.address }}</td>
+			  <td>{{ req.organisation }}</td>
+			  <td><a href="tel:{{ req.requestee_phone }}" >{{ req.phone }}</a></td>
+		  {% endif %}
           <td>{{ req.get_area_display }}</td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #835 

### Summarize
- Hide name, address & org in View Volunteers page for non authenticated users. If any user logs in they can see it.
- Also hide phone number in consent page


