### PR TITLE
css: reduce font-size of title to avoid vertical scroll

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,26 +53,26 @@ a.home-button:hover{
     background: #333333;
     color:#FFFFFF;
 }
-    a.home-button .glyphicon{
-        font-size: 5rem;
-        display: block;
-        margin-bottom: 10px;
-    }
-    a.home-button .text{
-        font-size: 2rem;
-        font-weight: 500;
-        text-transform: uppercase;
-        display:inline-block;
-    }
-    a.home-button .ml{
-        margin-top:7px;
-        padding-top:7px;
-        border-top: 1px dotted #555555;
-        font-size: 1.4rem;
-        font-weight: bold;
-        text-transform: uppercase;
-        display:inline-block;
-    }
+a.home-button .glyphicon{
+    font-size: 5rem;
+    display: block;
+    margin-bottom: 10px;
+}
+a.home-button .text{
+    font-size: 1.5rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    display:inline-block;
+}
+a.home-button .ml{
+    margin-top:7px;
+    padding-top:7px;
+    border-top: 1px dotted #555555;
+    font-size: 1.4rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    display:inline-block;
+}
 p.home-info{
     font-size: 1.6rem;
     font-weight: 500;


### PR DESCRIPTION
### Issue Reference
Fixes: https://github.com/IEEEKeralaSection/rescuekerala/issues/789

- Fix Vertical Scroll issue
- Reindented code

Did not disable vertical scroll as on the off content gets hidden.
`1.5 rem` keeps the whole tittle still prominent  

### Summarize
![x](https://user-images.githubusercontent.com/5358146/44423365-94d46580-a5a3-11e8-81c7-174d4147a629.gif)


