### PR TITLE
Add mobile no for private camps and pagination for relief camps list view

### DIFF
--- a/mainapp/templates/mainapp/pcamplist.html
+++ b/mainapp/templates/mainapp/pcamplist.html
@@ -26,19 +26,23 @@
 <table class="table table-hover">
     <thead>
         <tr>
+            <th>Center ID</th>
             <th>Name</th>
             <th>District</th>
             <th>LSG Type/LSG Name</th>
             <th>Total People</th>
+            <th>Contact Information</th>
             <th>Details</th>
         </tr>
     </thead>
     <tbody>
         {% for item in data %}
         <tr>
+            <td>{{ item.id }}</td>
             <td><strong>{{ item.name }}</strong></td>
             <td>{{ item.get_district_display }}</td>
             <td>{{ item.get_lsg_type_display }}<br>{{ item.lsg_name }}</td>
+            <td>{{ item.contacts }}
             <td>{{ item.total_people }}</td>
             <td>
                 <div class="btn-group">

--- a/mainapp/templates/mainapp/relief_camps_list.html
+++ b/mainapp/templates/mainapp/relief_camps_list.html
@@ -38,7 +38,7 @@
       <th>Contact Numbers</th>
       <th>Total People</th>
     </tr>
-    {% for item in relief_camps %}
+    {% for item in relief_camps_pag %}
     <tr valign="top">
       <td><strong>{{ item.get_district_display }}</strong></td>
       <td>
@@ -60,6 +60,29 @@
     </tr>
     {% endfor %}
   </table>
+
+  <!-- pagination part of  -->
+  {% if relief_camps_pag.has_other_pages %}
+  <ul class="pagination">
+    {% if relief_camps_pag.has_previous %}
+      <li><a href="?page={{ relief_camps_pag.previous_page_number }}">&laquo;</a></li>
+    {% else %}
+      <li class="disabled"><span>&laquo;</span></li>
+    {% endif %}
+    {% for i in relief_camps_pag.paginator.page_range %}
+      {% if relief_camps_pag.number == i %}
+        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+      {% else %}
+        <li><a href="?page={{ i }}">{{ i }}</a></li>
+      {% endif %}
+    {% endfor %}
+    {% if users.has_next %}
+      <li><a href="?page={{ relief_camps_pag.next_page_number }}">&raquo;</a></li>
+    {% else %}
+      <li class="disabled"><span>&raquo;</span></li>
+    {% endif %}
+  </ul>
+{% endif %}
 </div>
 {% elif district_chosen  %}
 <div class="text-center text-warning">

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -233,8 +233,10 @@ def relief_camps(request):
 def relief_camps_list(request):
     filter = RescueCampFilter(request.GET, queryset=RescueCamp.objects.filter(status='active'))
     relief_camps = filter.qs.annotate(count=Count('person')).order_by('district','name').all()
-
-    return render(request, 'mainapp/relief_camps_list.html', {'filter': filter , 'relief_camps' : relief_camps, 'district_chosen' : len(request.GET.get('district') or '')>0 })
+    paginator = Paginator(relief_camps,20)
+    page = request.GET.get('page')
+    req_reliefcamps = paginator.get_page(page)
+    return render(request, 'mainapp/relief_camps_list.html', {'filter': filter , 'relief_camps' : relief_camps, 'district_chosen' : len(request.GET.get('district') or '')>0,'relief_camps_pag': req_reliefcamps})
 
 
 class RequestFilter(django_filters.FilterSet):
@@ -730,6 +732,9 @@ class PrivateCampFilter(django_filters.FilterSet):
             'district' : ['exact'],
             'name' : ['icontains']
         }
+
+
+
 
     def __init__(self, *args, **kwargs):
         super(PrivateCampFilter, self).__init__(*args, **kwargs)


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #891  #546 

### Summarize
I have added phone no field on private relief camps and this fixes #891 
![screenshot from 2018-08-23 13-32-59](https://user-images.githubusercontent.com/24592806/44514997-154bb100-a6df-11e8-9ff1-9fd7062c5aea.png)
![screenshot from 2018-08-23 14-05-46](https://user-images.githubusercontent.com/24592806/44515003-17ae0b00-a6df-11e8-9888-2bf3f3ce5fdd.png)

Also I couldn't remove contents of my previous PR which fixes #546 

![44307946-7adf2b00-a3c9-11e8-8590-bdb3f784fcfb](https://user-images.githubusercontent.com/24592806/44515048-31e7e900-a6df-11e8-896e-c49e83a273c2.png)

This is PR is partially a duplicate of my previous PR #661 


> Please mention if there is any issues in PR . Thank You

