### PR TITLE
README Top link Spelling Corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <hr>
 
 ### Requirements
-[^toc](#table-of-contents)
+[^top](#table-of-contents)
 
 #### Docker
 <details>
@@ -80,7 +80,7 @@ Run it with sudo - `sudo sh docker.sh`
 <hr>
 
 ### Getting Started
-[^toc](#table-of-contents)
+[^top](#table-of-contents)
 
 ### Setting up a development environment
 
@@ -150,12 +150,12 @@ That's it!
 <hr>
 
 ### Creating migration files
-[^toc](#table-of-contents)
+[^top](#table-of-contents)
 
 If your code changes anything in models.py, you might need to make changes in database schema, or other constraints. To create migrations files, run python3 manage.py makemigrations --settings=floodrelief.settings after making your changes. Also make sure to add these files in the commit.
 
 ### Running tests
-[^toc](#table-of-contents)
+[^top](#table-of-contents)
 
 When running tests, Django creates a test replica of the database in order for the tests not to change the data on the real database. Because of that, you need to alter the Postgres user that you created and add to it the `CREATEDB` privilege:
 
@@ -172,7 +172,7 @@ python3 manage.py test --settings=floodrelief.test_settings
 <hr>
 
 ### Enable HTTPS connections
-[^toc](#table-of-contents)
+[^top](#table-of-contents)
 
 Certain features (example: GPS location collection) only work with HTTPS connections.  To enable HTTPS connections,follow the below steps.
 
@@ -208,7 +208,7 @@ In the above example the server is being run on a local IP address on port 8002 
 <hr>
 
 ## How can you help?
-[^toc](#table-of-contents)
+[^top](#table-of-contents)
 
 #### Verification of Rescue Requests
 


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Corrects the spelling on README.md file

### Summarize
Corrects the Spelling of **top** link on the README.md file


