### PR TITLE
Cache people filter form for 30min and expire on RescueCamp save

### DIFF
--- a/mainapp/models.py
+++ b/mainapp/models.py
@@ -9,6 +9,10 @@ from django.core.validators import RegexValidator
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.core.exceptions import ValidationError
+from django.db.models.signals import post_save
+from django.core.cache.utils import make_template_fragment_key
+from django.core.cache import cache
+from django.dispatch import receiver
 
 
 districts = (
@@ -369,6 +373,12 @@ class RescueCamp(models.Model):
 
     def __str__(self):
         return self.name
+
+
+@receiver(post_save, sender=RescueCamp)
+def expire_people_filter_form(sender, **kwargs):
+    cache_key = make_template_fragment_key("person_filter_form")
+    cache.delete(cache_key)
 
 
 class PrivateRescueCamp(models.Model):

--- a/mainapp/templates/mainapp/people.html
+++ b/mainapp/templates/mainapp/people.html
@@ -12,9 +12,13 @@
     <div class="col-md-4">
         <form action="" method="get" class="simple-form">
             Search with name, mobile number etc. <br>
-            പേരോ മൊബൈൽ നമ്പറോ ഉപയോഗിച്ച് തിരയാം 
+            പേരോ മൊബൈൽ നമ്പറോ ഉപയോഗിച്ച് തിരയാം
             <hr>
-              {% bootstrap_form filter.form bound_css_class=False %}
+              {% load cache %}
+              {% cache 1800 person_filter_form %}
+                {% bootstrap_form filter.form bound_css_class=False %}
+              {% endcache %}
+
 
           <button type="submit" class="btn btn-success btn-lg">Search {% bootstrap_icon "chevron-right" %}</button>
       </form>
@@ -43,7 +47,7 @@
                   </tr>
               {% endfor %}
             </table>
-            
+
             {% if data.paginator.num_pages > 1 %}
             <div class="pagination" >
               <span class="step-links">
@@ -51,7 +55,7 @@
                       <a href="?page=1&name__icontains={{ request.GET.name__icontains }}&phone__icontains={{ request.GET.phone__icontains }}&address__icontains={{ request.GET.address__icontains }}&district={{ request.GET.district }}&notes__icontains={{ request.GET.notes__icontains }}&gender={{ request.GET.gender }}&camped_at={{ request.GET.camped_at }}">&laquo; first</a>
                       <a href="?page={{data.previous_page_number}}&name__icontains={{ request.GET.name__icontains }}&phone__icontains={{ request.GET.phone__icontains }}&address__icontains={{ request.GET.address__icontains }}&district={{ request.GET.district }}&notes__icontains={{ request.GET.notes__icontains }}&gender={{ request.GET.gender }}&camped_at={{ request.GET.camped_at }}">previous</a>
                   {% endif %}
-            
+
                   {% for i in data.paginator.page_range %}
                   {% if data.number == i %}
                     <a class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></a>
@@ -59,7 +63,7 @@
                     <a href="?page={{i}}&name__icontains={{ request.GET.name__icontains }}&phone__icontains={{ request.GET.phone__icontains }}&address__icontains={{ request.GET.address__icontains }}&district={{ request.GET.district }}&notes__icontains={{ request.GET.notes__icontains }}&gender={{ request.GET.gender }}&camped_at={{ request.GET.camped_at }}">{{ i }}</a>
                   {% endif %}
                 {% endfor %}
-            
+
                   {% if data.has_next %}
                       <a href="?page={{ data.next_page_number }}&name__icontains={{ request.GET.name__icontains }}&phone__icontains={{ request.GET.phone__icontains }}&address__icontains={{ request.GET.address__icontains }}&district={{ request.GET.district }}&notes__icontains={{ request.GET.notes__icontains }}&gender={{ request.GET.gender }}&camped_at={{ request.GET.camped_at }}">next</a>
                       <a href="?page={{ data.paginator.num_pages }}&name__icontains={{ request.GET.name__icontains }}&phone__icontains={{ request.GET.phone__icontains }}&address__icontains={{ request.GET.address__icontains }}&district={{ request.GET.district }}&notes__icontains={{ request.GET.notes__icontains }}&gender={{ request.GET.gender }}&camped_at={{ request.GET.camped_at }}">last &raquo;</a>
@@ -67,9 +71,9 @@
               </span>
             </div>
             {% endif %}
-          
+
           </div>
-    
+
       </div>
 </div>
 


### PR DESCRIPTION
Addressing latency spikes on /find_people

It's an outlier:
![image](https://user-images.githubusercontent.com/91915/44557594-1804d100-a6f4-11e8-8cc7-e2a2ea07127d.png)

And the time is spent in django rendering code:
![image](https://user-images.githubusercontent.com/91915/44557627-32d74580-a6f4-11e8-9249-35a8e48a9306.png)

To test locally:

- create an admin user `python3 manage.py createsuperuser`
- create a camp, see if it shows up on the `/find_people` form