### PR TITLE
add missing persons page as per #918

### DIFF
--- a/mainapp/templates/mainapp/missing_persons.html
+++ b/mainapp/templates/mainapp/missing_persons.html
@@ -41,6 +41,6 @@
 </div>
 
 <div class="text-center">
-    <iframe width="100%" height="1200" style="max-width:1200px;" src="https://keralarescuemap.ushahidi.io/posts/create/4" frameborder="0" allowfullscreen></iframe>
+    <iframe width="100%" height="1200" allow="geolocation" style="max-width:1200px;" src="https://keralarescuemap.ushahidi.io/posts/create/4" frameborder="0" allowfullscreen></iframe>
 </div>
 {% endblock %}

--- a/mainapp/templates/mainapp/missing_persons.html
+++ b/mainapp/templates/mainapp/missing_persons.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<h3 class="text-center">
+    Kerala Flood: Report Missing persons <br />
+    കേരളം പ്രളയം: കാണാതായ വ്യക്തികളെ റിപ്പോർട്ട് ചെയ്യുക
+</h3>
+
+<div class="text-center">
+
+    <p>This is a crowdsourced website that aims to track all the persons missing during the Kerala floods. Add as much information as possible so that volunteers can help search for your loved ones in the relief camps. Once you enter the details we will do the below: </p>
+
+    <ul>
+        <li>The missing person details will be shown on our website prominently
+        <li>The details may be shared on Facebook and other social media to help track people
+        <li>The volunteers on ground may post the missing person details on walls or o ther prominent places within the relief camps
+        <li>We will make every effort to find the missing persons, but if the person cannot be located the details would be shared with the Police through the Thuna Portal
+    </ul>
+
+
+    <p>Help us avoid fake reports! Share at least 3 contact numbers so that we can verify the missing person report.</p>
+
+<p>
+    കേരള വെള്ളപ്പൊക്കത്തിൽ കാണാതായ എല്ലാവരെയും ട്രാക്ക് ചെയ്യാൻ ലക്ഷ്യമിട്ടുള്ള ഒരു വെബ് സൈറ്റ് ആണ് ഇത്. സന്നദ്ധപ്രവർത്തകർ ദുരിതാശ്വാസ ക്യാമ്പുകളിൽ തിരയാൻ സഹായിക്കുന്നതിന് കഴിയുന്നിടത്തോളം വിശദാംശങ്ങൾ ചേർക്കുക. നിങ്ങൾ നൽകുന്ന വിശദാംശങ്ങൾ ഞങ്ങൾ ചുവടെയുള്ള സ്ഥലങ്ങളിൽ ഉപയോഗിക്കും:
+</p>
+
+<p>
+കാണാതായ വ്യക്തിയുടെ വിശദാംശങ്ങൾ ഞങ്ങളുടെ വെബ്സൈറ്റിൽ പ്രദർശിപ്പിക്കും
+ആളുകളുടെ വിവരങ്ങൾ അറിയാൻ Facebook, മറ്റ് സോഷ്യൽ മീഡിയകൾ എന്നിവയിലൂടെ വിവരങ്ങൾ പങ്കിടാം
+</p>
+
+<p>
+കാണാതായ വ്യക്തികളുടെ വിശദാംശങ്ങൾ ദുരിതാശ്വാസ ക്യാമ്പ് ചുമരുകളിൽ പ്രദർശിപ്പിക്കും <br />
+കാണാതായവരെ കണ്ടെത്താൻ എല്ലാ ശ്രമങ്ങളും നടത്തും, എന്നാൽ ഞങ്ങൾക്ക് കണ്ടെത്താൻ കഴിഞ്ഞില്ലെങ്കിൽ വിശദാംശങ്ങൾ Thuna പോർട്ടലിലൂടെ പോലീസുമായി പങ്കുവെക്കപ്പെടും.
+</p>
+
+<p>
+വ്യാജ റിപ്പോർട്ടുകൾ ഒഴിവാക്കാൻ ഞങ്ങളെ സഹായിക്കൂ! കാണാതായ വ്യക്തിയുടെ റിപ്പോർട്ട് ഞങ്ങൾക്ക് സ്ഥിരീകരിക്കാനായി ചുരുങ്ങിയത് 3 കോൺടാക്റ്റ് നമ്പറുകൾ പങ്കിടുക.
+</p>
+</div>
+
+<div class="text-center">
+    <iframe width="100%" height="1200" style="max-width:1200px;" src="https://keralarescuemap.ushahidi.io/posts/create/4" frameborder="0" allowfullscreen></iframe>
+</div>
+{% endblock %}

--- a/mainapp/templates/mainapp/relief_camps.html
+++ b/mainapp/templates/mainapp/relief_camps.html
@@ -40,14 +40,6 @@
             <span class="ml small"></span>
         </span>
     </a>
-    <a href="/find_people" class="home-button card" role="button">
-        {% bootstrap_icon "user" %}
-        <span class="text text-center">
-            Person Finder<br/>
-            വ്യക്തിയെ തിരയുക
-            <span class="ml small"></span>
-        </span>
-    </a>
     <a href="/camp_requirements" class="home-button card" role="button">
         {% bootstrap_icon "list" %}
         <span class="text text-center">
@@ -56,6 +48,23 @@
             <span class="ml small"></span>
         </span>
     </a>
+    <a href="/find_people" class="home-button card" role="button">
+        {% bootstrap_icon "user" %}
+        <span class="text text-center">
+            Person Finder<br/>
+            വ്യക്തിയെ തിരയുക
+            <span class="ml small"></span>
+        </span>
+    </a>
+    <a href="/missing_persons" class="home-button card" role="button">
+        {% bootstrap_icon "user" %}
+        <span class="text text-center">
+            Missing Persons<br/>
+            കാണാതായ വ്യക്തികളെ റിപ്പോർട്ട് ചെയ്യുക
+            <span class="ml small"></span>
+        </span>
+    </a>    
+
 
     <p class="home-info">
         Contact Control Room or Disaster Management Cell or District Administration for any support.<br>

--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     path('camp/<int:camp_id>/add_person/', views.AddPerson.as_view(), name='add_person'),
     path('coordinator_home/', views.coordinator_home, name='coordinator_home'),
     path('find_people/', views.find_people, name='find_people'),
+    path('missing_persons/', views.missing_persons, name='missing_persons'),
     path('announcements/', views.announcements, name="Announcements"),
     path('camp_requirements/', views.camp_requirements_list, name='camp_requirements_list'),
     path('submission_success/', views.SubmissionSuccess.as_view(), name='submission_success'),

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -230,6 +230,9 @@ class RescueCampFilter(django_filters.FilterSet):
 def relief_camps(request):
     return render(request,"mainapp/relief_camps.html")
 
+def missing_persons(request):
+    return render(request, "mainapp/missing_persons.html")
+
 
 def relief_camps_list(request):
     filter = RescueCampFilter(request.GET, queryset=RescueCamp.objects.filter(status='active'))


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes #918

### Summarize

 - Move order of buttons on `relief_camps` page
 - Add button to link to new `missing_persons` page
 - Create url and view for `missing_persons` page
 - Add intro text and form embed to `missing_persons` page

> Also, mention the key points if any to look into while code reviews

 - Mostly the styling of the form - the form is really long and their embed seems to have the submit button only at the top - not sure if this is confusing - we can reduce  the height of the embed, but then there will be a lot of internal scroll.

cc @naveenpf 