### PR TITLE
reduce size of ushahidi embed form to remove left side-bar

### DIFF
--- a/mainapp/templates/mainapp/missing_persons.html
+++ b/mainapp/templates/mainapp/missing_persons.html
@@ -41,6 +41,6 @@
 </div>
 
 <div class="text-center">
-    <iframe width="100%" height="1200" allow="geolocation" style="max-width:1200px;" src="https://keralarescuemap.ushahidi.io/posts/create/4" frameborder="0" allowfullscreen></iframe>
+    <iframe width="100%" height="1200" allow="geolocation" style="max-width:800px;" src="https://keralarescuemap.ushahidi.io/posts/create/4" frameborder="0" allowfullscreen></iframe>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Issue Reference
This PR addresses the Issue : Fixes Ushahidi embed form on missing persons page width.

### Summarize
  Minor - reduces the width of the Ushahidi embed form on the `missing_persons` page, so that the left sidebar, which was confusing, no longer shows

cc @naveenpf @bobinson 
