### PR TITLE
Added requirements_debug.txt to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && apt-get install -y netcat
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
+ADD requirements_debug.txt /code/
 RUN pip install -r requirements.txt
+RUN pip install -r requirements_debug.txt 
 ADD . /code/
 ADD wait.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/wait.sh


### PR DESCRIPTION

Added requirements_debug.txt to Dockerfile

Without this, it gives the following error while running in Docker.
ModuleNotFoundError: No module named 'debug_toolbar'