### PR TITLE
Commented out toll free number

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -82,11 +82,15 @@
     <span>&nbsp;|&nbsp;</span>
     <a href="https://github.com/IEEEKeralaSection/rescuekerala/" target="_blank">GitHub</a>
     <br /><br />
-    <span>
+
+    <!-- temporarily commented out since its #KeralaFloods2018 number
+      <span>
         നിങ്ങളുടെ എല്ലാ ആരോഗ്യസംബന്ധ സംശയങ്ങൾക്കും വിളിക്കാം ടോൾ ഫ്രീ നമ്പർ <strong><a href="tel:18001231454">1800 123 1454</a></strong><br />
         Call toll free number <strong><a href="tel:18001231454">1800 123 1454</a></strong> for all your health related questions.<br />
         24x7 Helpline Call Centre, Disaster Control Unit, Directorate of Health Services, Government of Kerala.<br />
-    </span>
+      </span>
+    -->
+    
     {# &nbsp;&nbsp;&nbsp;-&nbsp;&nbsp;&nbsp; #}
     {# <a href="/ieee/"><img src="{% static 'images/ieeelogo.png' %}" class="footer-logo"></a> #}
   </div>


### PR DESCRIPTION
Commented out 2018 DHS toll-free number as it is not valid anymore.
If a new number is setup, the lines can be uncommented.
