### PR TITLE
Corrected Cordinator App download link fixes #1072

### DIFF
--- a/mainapp/templates/mainapp/relief_camps.html
+++ b/mainapp/templates/mainapp/relief_camps.html
@@ -20,7 +20,7 @@
     <a class="btn btn-default" href="/coordinator_home" style="margin-top: 5px;">
       Coordinator Login
     </a>
-    <a class="btn btn-info" href="https://play.google.com/store/apps/details?id=xyz.appmaker.keralarescue" style="margin-top: 5px;">
+    <a class="btn btn-info" href="https://cdn.keralarescue.in/app/keralarescuecamp.apk" style="margin-top: 5px;">
       Coordinator App
     </a>
     <p>


### PR DESCRIPTION
#729 # Issue Reference
This PR addresses the Issue : Fixes #1072

### Summarize
Earlier the coordinator app download link was pointing to a play store link  which returns an error  now the link points to 
https://cdn.keralarescue.in/app/keralarescuecamp.apk
